### PR TITLE
Set up development environment (build/test/lint) for the Screeps bot

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module"
+  },
+  plugins: ["@typescript-eslint", "import"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "plugin:import/typescript",
+    "prettier",
+    "plugin:prettier/recommended"
+  ],
+  env: {
+    es6: true,
+    node: true
+  },
+  settings: {
+    "import/resolver": {
+      typescript: {}
+    }
+  },
+  rules: {}
+};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single product: a **Screeps** AI bot (`screeps-typescript-starter` based).
+There is no long-running local service. The "application" is the TypeScript in `src/`
+bundled by Rollup into `dist/main.js`, which is uploaded to (and executed by) a Screeps
+game server. Standard commands live in `package.json` `scripts` — use those.
+
+### Environment
+- Node: `package.json` `engines` pins `10.x || 12.x` and `.devcontainer` uses `node:12-alpine`,
+  but everything below (build, unit-test tooling, lint) runs fine on the VM's default **Node 22**.
+  Do not switch to Node 12 with `nvm`; the exec-daemon `node` shim stays on 22 and mixing them
+  leaves `npm` pointing at Node 12's `npm@6` and breaks `npm run <script>`.
+- `npm install` installs all committed dev tooling (Rollup, ts-node/mocha, ESLint/Prettier).
+  There is no committed lockfile (`package-lock.json` is gitignored).
+
+### Build / run the bot
+- `npm run build` → compiles `src/main.ts` to `dist/main.js` (+ `dist/main.js.map.js`).
+- Non-obvious: `rollup.config.js` passes an explicit `include` to `rollup-plugin-typescript2`.
+  Without it, the plugin's default extglob patterns (`**/*.ts+(|x)`) do not match under the
+  modern `@rollup/pluginutils` (picomatch) that gets installed, so every `.ts` file is passed
+  through untransformed and the build fails with "Unexpected token". Keep that `include`.
+- Uploading to a live server (`npm run push-*` / `watch-*`) needs a gitignored `screeps.json`
+  (copy `screeps.example.json`) with a token or email/password. Not needed to build or test.
+
+### Lint
+- `npm run lint` runs ESLint over `src/**/*.ts` using `.eslintrc.js`.
+- It currently reports thousands of PRE-EXISTING findings (mostly `prettier/prettier`
+  formatting — the code was never linted), so it exits non-zero. That is code state, not a
+  tooling problem. `npx eslint --fix "src/**/*.ts"` would auto-fix most, but only do that if asked.
+
+### Unit tests
+- `npm test` (= `test-unit`) runs `mocha test/unit/**/*.ts` via `ts-node` + `tsconfig-paths`.
+- The runner is wired through `test/mocha.opts` + `test/setup-mocha.js`, which sets
+  `TS_NODE_PROJECT=tsconfig.test.json` (a small CommonJS override of `tsconfig.json`).
+- Non-obvious: the current single unit test transitively imports `src/utils/ErrorExporter.ts`,
+  which calls the Screeps global `RawMemory` at import time. `test/unit/mock.ts` only stubs
+  `Game`/`Memory`, so the suite throws `ReferenceError: RawMemory is not defined`. This is a
+  code/test-fixture gap in the repo, not an environment issue — running the actual bot logic
+  end-to-end is better done via the integration path below.
+
+### Integration test (optional, best end-to-end proof)
+- `test/integration/**/*.ts` boots an in-process mock Screeps server via `screeps-server-mockup`,
+  loads the built `dist/main.js` as a bot, and runs game ticks. This is the closest thing to
+  "running the app" locally.
+- `screeps-server-mockup` is intentionally NOT in `package.json` (it pulls the full `screeps`
+  server incl. native `isolated-vm` built from git — a slow, heavy install of ~500 packages).
+  It is therefore not part of the update script. To run integration tests, install it on demand:
+  `npm install --no-save screeps-server-mockup@1.5.1` (takes several minutes), then
+  `npm run build && npx mocha "test/integration/**/*.ts"`.
+- Expect the "runs a server and matches the game tick" test to pass (bot boots + ticks). The
+  "writes and reads to memory" test fails by design: the bot's `MemHack` (`src/utils/MemHack.ts`)
+  replaces `global.Memory` with a cached reference each tick, dropping externally-injected
+  `Memory.foo`. Not an environment issue.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default {
     clear({ targets: ["dist"] }),
     resolve({ rootDir: "src" }),
     commonjs(),
-    typescript({tsconfig: "./tsconfig.json"}),
+    typescript({tsconfig: "./tsconfig.json", include: ["*.ts+(|x)", "**/*.ts+(|x)", "**/*.ts", "**/*.tsx"]}),
     screeps({config: cfg, dryRun: cfg == null})
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJs"
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a working development environment for this Screeps TypeScript bot so the standard dev workflow — **build**, **unit-test tooling**, **lint**, and an **end-to-end mock-server run** — all function. No application logic in `src/` was changed; only build/test/lint configuration required to make the tooling run, plus docs.

## What was broken and why

The repo had no committed lockfile, so `npm install` resolves modern transitive versions that break the (old, floating) toolchain:

- **Build**: `rollup-plugin-typescript2`'s default extglob include patterns (`**/*.ts+(|x)`) no longer match under the `@rollup/pluginutils` (picomatch) that gets installed, so the plugin skipped every `.ts` file and Rollup tried to parse raw TypeScript → `Unexpected token`.
- **Unit tests**: `test/setup-mocha.js` sets `TS_NODE_PROJECT=tsconfig.test.json`, but that file had been deleted from the repo, so `ts-node` errored with `Cannot read file '.../tsconfig.test.json'`.
- **Lint**: the repo ships the full ESLint + Prettier + import toolchain and a `lint` script, but no ESLint config was ever committed, so `npm run lint` errored with "couldn't find a configuration file".

## Changes

- `rollup.config.js`: pass an explicit, backward-compatible `include` to `rollup-plugin-typescript2` so its transform runs.
- `tsconfig.test.json`: restore the deleted CommonJS test tsconfig referenced by the mocha setup.
- `.eslintrc.js`: add the standard `screeps-typescript-starter` ESLint config wired to the already-installed plugins.
- `AGENTS.md`: add Cursor Cloud setup/run notes.

## Verification

- `npm run build` → produces `dist/main.js` (~1.48 MB) + source map.
- `npx mocha "test/integration/**/*.ts"` (after installing the optional `screeps-server-mockup`): boots an in-process mock Screeps server, loads the compiled `dist/main.js` as bot `player`, and runs game ticks — **"runs a server and matches the game tick" passes** (the bot actually executes in a live mock game). The second memory test fails by design because the bot's `MemHack` swaps `global.Memory` each tick.
- `npm run lint` runs and reports pre-existing findings (code was never linted); exit≠0 is code state, not tooling.
- `npm test` runner works (ts-node compiles); the single existing unit test then throws on a pre-existing code issue (`src/utils/ErrorExporter.ts` uses the `RawMemory` global at import time, which `test/unit/mock.ts` doesn't stub).

## Notes

- Update script for the environment is `npm install` (installs all committed dev tooling; there's no lockfile).
- `screeps-server-mockup` is intentionally **not** added to `package.json` / the update script because it pulls the full `screeps` server incl. native `isolated-vm` built from git (~500 pkgs, several minutes). Integration testing is documented as an optional on-demand step in `AGENTS.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d73a090d-d087-4f89-8074-0313ee2b212a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d73a090d-d087-4f89-8074-0313ee2b212a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

